### PR TITLE
Fix OIDC auth failure when server doesn't provide scope

### DIFF
--- a/ci/compose.sh
+++ b/ci/compose.sh
@@ -19,5 +19,5 @@ function compose_down_all {
 }
 
 function all_weaviate_ports {
-  echo "8080 8081 8082 8083 8085"
+  echo "8080 8081 8082 8083 8085 8086"
 }

--- a/ci/docker-compose-wcs-noscope.yml
+++ b/ci/docker-compose-wcs-noscope.yml
@@ -1,0 +1,27 @@
+---
+version: '3.4'
+services:
+  weaviate-auth-wcs-noscopes:
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - '8086'
+      - --scheme
+      - http
+      - --write-timeout=600s
+    image: semitechnologies/weaviate:1.17.0
+    ports:
+      - 8086:8086
+    restart: on-failure:0
+    environment:
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+      AUTHENTICATION_OIDC_ENABLED: 'true'
+      AUTHENTICATION_OIDC_CLIENT_ID: 'wcs'
+      AUTHENTICATION_OIDC_ISSUER: 'https://auth.wcs.api.semi.technology/auth/realms/SeMI'
+      AUTHENTICATION_OIDC_USERNAME_CLAIM: 'email'
+      AUTHENTICATION_OIDC_GROUPS_CLAIM: 'groups'
+      AUTHORIZATION_ADMINLIST_ENABLED: 'true'
+      AUTHORIZATION_ADMINLIST_USERS: 'ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net'
+...

--- a/connection/auth.js
+++ b/connection/auth.js
@@ -49,10 +49,11 @@ export class Authenticator {
   getOpenidConfig = async (localConfig) => {
     return this.http.externalGet(localConfig.href)
       .then(openidProviderConfig => {
+        let scopes = localConfig.scopes || [];
         return {
           clientId: localConfig.clientId,
           provider: openidProviderConfig,
-          scopes: localConfig.scopes
+          scopes: scopes
         };
       });
   };

--- a/connection/journey.test.js
+++ b/connection/journey.test.js
@@ -103,6 +103,25 @@ describe("connection", () => {
       .catch((e) => fail("it should not have errord: " + e));
   })
 
+  it("makes a scopeless WCS logged-in request with username/password", async () => {
+    const client = weaviate.client({
+      scheme: "http",
+      host: "localhost:8086",
+      authClientSecret: new AuthUserPasswordCredentials({
+        username: "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net",
+        password: process.env.WCS_DUMMY_CI_PW
+      })
+    })
+
+    return client.misc
+      .metaGetter()
+      .do()
+      .then((res) => {
+        expect(res.version).toBeDefined();;
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
   it("makes a logged-in request with access token", async () => {
     if (process.env.WCS_DUMMY_CI_PW == undefined || process.env.WCS_DUMMY_CI_PW == "") {
       console.warn("Skipping because `WCS_DUMMY_CI_PW` is not set");


### PR DESCRIPTION
The OIDC config which is provided to the various authenticators was being passed with `scopes: undefined` when the server is configured without scopes.

This patch fixes the problem by setting `scopes: []` when none are returned by the server.