### PR TITLE
add support for tunable write consistency

### DIFF
--- a/batch/journey.test.js
+++ b/batch/journey.test.js
@@ -179,9 +179,10 @@ describe("batch importing", () => {
         },
       ];
 
-      it("imports them", () => {
+      it("imports them with consistency level", () => {
         client.batch
           .objectsBatcher()
+          .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ONE)
           .withObjects([toImport[0], toImport[1]])
           .do()
           .then()
@@ -215,7 +216,7 @@ describe("batch importing", () => {
       })
     });
 
-    it("imports the refs with raw objects", () => {
+    it("imports the refs with raw objects and consistency level", () => {
       return client.batch
         .referencesBatcher()
         .withReference({
@@ -226,6 +227,7 @@ describe("batch importing", () => {
           from: `weaviate://localhost/${thingClassName}/${thingIds[1]}/refProp`,
           to: `weaviate://localhost/${otherThingClassName}/${otherThingIds[1]}`,
         })
+        .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ALL)
         .do()
         .then((res) => {
           res.forEach((elem) => {
@@ -429,7 +431,7 @@ describe("batch deleting", () => {
       })
   )
 
-  it("batch deletes with default dryRun", () => {
+  it("batch deletes with default dryRun and consistency level", () => {
     const inAMinute = "" + (new Date().getTime() + 60 * 1000);
     return client.batch
       .objectsBatchDeleter()
@@ -440,6 +442,7 @@ describe("batch deleting", () => {
         path: ["_creationTimeUnix"]
       })
       .withOutput(weaviate.batch.DeleteOutput.VERBOSE)
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.QUORUM)
       .do()
       .then(result => {
         expect(result.dryRun).toBe(false);

--- a/batch/objectsBatchDeleter.js
+++ b/batch/objectsBatchDeleter.js
@@ -1,4 +1,5 @@
 import { isValidStringProperty } from "../validation/string";
+import { buildObjectsPath } from "./path"
 
 export default class ObjectsBatchDeleter {
   className;
@@ -30,6 +31,11 @@ export default class ObjectsBatchDeleter {
     this.dryRun = dryRun;
     return this;
   }
+
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
 
   payload() {
     return {
@@ -72,7 +78,11 @@ export default class ObjectsBatchDeleter {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = `/batch/objects`;
+    let params = new URLSearchParams()
+    if (this.consistencyLevel) {
+      params.set("consistency_level", this.consistencyLevel)
+    }
+    const path = buildObjectsPath(params);
     return this.client.delete(path, this.payload(), true);
   };
 }

--- a/batch/objectsBatcher.js
+++ b/batch/objectsBatcher.js
@@ -1,3 +1,5 @@
+import { buildObjectsPath } from "./path"
+
 export default class ObjectsBatcher {
   constructor(client) {
     this.client = client;
@@ -25,6 +27,11 @@ export default class ObjectsBatcher {
     return this.withObjects(object);
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   payload = () => ({
     objects: this.objects,
   });
@@ -50,7 +57,11 @@ export default class ObjectsBatcher {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = `/batch/objects`;
+    let params = new URLSearchParams()
+    if (this.consistencyLevel) {
+      params.set("consistency_level", this.consistencyLevel)
+    }
+    const path = buildObjectsPath(params);
     return this.client.post(path, this.payload());
   };
 }

--- a/batch/path.js
+++ b/batch/path.js
@@ -1,0 +1,16 @@
+export function buildObjectsPath(queryParams) {
+  let path = "/batch/objects";
+  return buildPath(path, queryParams)
+}
+
+export function buildRefsPath(queryParams) {
+  let path = "/batch/references";
+  return buildPath(path, queryParams)
+}
+
+function buildPath(path, queryParams) {
+  if (queryParams && queryParams.toString() != "") {
+    path = `${path}?${queryParams.toString()}`
+  }
+  return path
+}

--- a/batch/path.test.js
+++ b/batch/path.test.js
@@ -1,0 +1,27 @@
+import { buildObjectsPath, buildRefsPath } from "./path"
+
+describe("paths", () => {
+  it("builds batch objects without params", () => {
+    let path = buildObjectsPath(new URLSearchParams())
+    expect(path).toEqual("/batch/objects")
+  })
+
+  it("builds batch objects with params", () => {
+    let path = buildObjectsPath(new URLSearchParams({
+      consistency_level: "ONE"
+    }))
+    expect(path).toEqual("/batch/objects?consistency_level=ONE")
+  })
+
+  it("builds batch references without params", () => {
+    let path = buildRefsPath(new URLSearchParams())
+    expect(path).toEqual("/batch/references")
+  })
+
+  it("builds batch object with params", () => {
+    let path = buildRefsPath(new URLSearchParams({
+      consistency_level: "ONE"
+    }))
+    expect(path).toEqual("/batch/references?consistency_level=ONE")
+  })
+})

--- a/batch/referencesBatcher.js
+++ b/batch/referencesBatcher.js
@@ -1,3 +1,5 @@
+import { buildRefsPath } from "./path"
+
 export default class ReferencesBatcher {
   constructor(client, beaconPath) {
     this.client = client;
@@ -26,6 +28,11 @@ export default class ReferencesBatcher {
     return this.withReferences(reference);
   }
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   payload = () => this.references;
 
   validateReferenceCount = () => {
@@ -49,7 +56,11 @@ export default class ReferencesBatcher {
         new Error("invalid usage: " + this.errors.join(", "))
       );
     }
-    const path = `/batch/references`;
+    let params = new URLSearchParams()
+    if (this.consistencyLevel) {
+      params.set("consistency_level", this.consistencyLevel)
+    }
+    const path = buildRefsPath(params);
     const payloadPromise = Promise.all(this.references.map(ref => this.rebuildReferencePromise(ref)));
 
     return payloadPromise.then(payload => this.client.post(path, payload));

--- a/ci/docker-compose-azure-cc.yml
+++ b/ci/docker-compose-azure-cc.yml
@@ -11,7 +11,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-replace-shardingconfig-replicas-with-replication-factor-29e987d
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.15.4-b7811d4
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.17.0
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-wcs-noscope.yml
+++ b/ci/docker-compose-wcs-noscope.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.17.0
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.17.0
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate:
-    image: semitechnologies/weaviate:1.17.0
+    image: semitechnologies/weaviate:1.18.0-alpha.0-be532d2
     restart: on-failure:0
     ports:
       - "8080:8080"

--- a/cluster/journey.test.js
+++ b/cluster/journey.test.js
@@ -1,8 +1,8 @@
 const weaviate = require("../index");
 const { createTestFoodSchemaAndData, cleanupTestFood, PIZZA_CLASS_NAME, SOUP_CLASS_NAME } = require("../utils/testData");
 
-const EXPECTED_WEAVIATE_VERSION = "1.17.0"
-const EXPECTED_WEAVIATE_GIT_HASH = "37d3b17"
+const EXPECTED_WEAVIATE_VERSION = "1.18.0-alpha.0"
+const EXPECTED_WEAVIATE_GIT_HASH = "be532d2"
 
 describe("cluster nodes endpoint", () => {
   const client = weaviate.client({

--- a/data/creator.js
+++ b/data/creator.js
@@ -27,6 +27,11 @@ export default class Creator {
     return this;
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateClassName = () => {
     if (!isValidStringProperty(this.className)) {
       this.errors = [
@@ -55,7 +60,7 @@ export default class Creator {
       );
     }
 
-    return this.objectsPath.buildCreate()
-      .then(path => this.client.post(path, this.payload()))
+    return this.objectsPath.buildCreate(this.consistencyLevel)
+      .then(path => this.client.post(path, this.payload()));
   };
 }

--- a/data/deleter.js
+++ b/data/deleter.js
@@ -15,6 +15,11 @@ export default class Deleter {
     return this;
   }
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateIsSet = (prop, name, setter) => {
     if (prop == undefined || prop == null || prop.length == 0) {
       this.errors = [
@@ -40,7 +45,7 @@ export default class Deleter {
     }
     this.validate();
 
-    return this.objectsPath.buildDelete(this.id, this.className)
+    return this.objectsPath.buildDelete(this.id, this.className, this.consistencyLevel)
       .then(this.client.delete);
   };
 }

--- a/data/journey.test.js
+++ b/data/journey.test.js
@@ -618,6 +618,381 @@ describe("data", () => {
       .catch((e) => fail("it should not have errord: " + e));
   })
 
+  it("creates object with consistency_level set", async () => {
+    const id = "144d1944-3ab4-4aa1-8095-92429d6cbaba";
+    const properties = { foo: "bar" };
+    const vector = [-0.26736435, -0.112380296, 0.29648793, 0.39212644, 0.0033650293, -0.07112332, 0.07513781, 0.22459874];
+
+    await client.data
+      .creator()
+      .withClassName(classCustomVectorClassName)
+      .withProperties(properties)
+      .withVector(vector)
+      .withId(id)
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ALL)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(properties);
+        expect(res.vector).toEqual(vector);
+        expect(res.id).toEqual(id);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: properties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("deletes object with consistency_level set", async () => {
+    const id = "7a78b029-e7b4-499f-9bd8-70ea11b12345";
+    const properties = { foo: "bar" };
+    const vector = [-0.26736435, -0.112380296, 0.29648793, 0.39212644, 0.0033650293, -0.07112332, 0.07513781, 0.22459874];
+
+    await client.data
+      .creator()
+      .withClassName(classCustomVectorClassName)
+      .withProperties(properties)
+      .withVector(vector)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(properties);
+        expect(res.vector).toEqual(vector);
+        expect(res.id).toEqual(id);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: properties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .deleter()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.QUORUM)
+      .do()
+      .then()
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("patches object with consistency_level set", async () => {
+    const id = "7a78b029-e7b4-499f-9bd8-70ea11b12345";
+    const properties = { foo: "bar" };
+    const vector = [-0.26736435, -0.112380296, 0.29648793, 0.39212644, 0.0033650293, -0.07112332, 0.07513781, 0.22459874];
+
+    await client.data
+      .creator()
+      .withClassName(classCustomVectorClassName)
+      .withProperties(properties)
+      .withVector(vector)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(properties);
+        expect(res.vector).toEqual(vector);
+        expect(res.id).toEqual(id);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: properties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    const newProperties = { foo: "baz" }
+
+    await client.data
+      .merger()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .withProperties(newProperties)
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.QUORUM)
+      .do()
+      .then()
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: newProperties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("updates object with consistency_level set", async () => {
+    const id = "55eaf761-11fd-48a9-bf21-60e2048db188";
+    const properties = { foo: "bar" };
+    const vector = [-0.26736435, -0.112380296, 0.29648793, 0.39212644, 0.0033650293, -0.07112332, 0.07513781, 0.22459874];
+
+    await client.data
+      .creator()
+      .withClassName(classCustomVectorClassName)
+      .withProperties(properties)
+      .withVector(vector)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(properties);
+        expect(res.vector).toEqual(vector);
+        expect(res.id).toEqual(id);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: properties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    const newProperties = { foo: "baz" }
+
+    await client.data
+      .updater()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .withProperties(newProperties)
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.QUORUM)
+      .do()
+      .then()
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .getterById()
+      .withClassName(classCustomVectorClassName)
+      .withId(id)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id,
+            properties: newProperties,
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("creates reference with consistency_level set", async () => {
+    const id1 = "5a99f759-400a-453e-b83a-766472994d05";
+    const props1 = { stringProp: "foobar" };
+
+    const id2 = "8d3ae97a-664b-4252-91d5-9886eda9b580";
+
+    await client.data
+      .creator()
+      .withClassName(thingClassName)
+      .withProperties(props1)
+      .withId(id1)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(props1);
+        expect(res.id).toEqual(id1);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .creator()
+      .withClassName(refSourceClassName)
+      .withId(id2)
+      .do()
+      .then((res) => {
+        expect(res.id).toEqual(id2);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .referenceCreator()
+      .withId(id2)
+      .withReferenceProperty("refProp")
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ONE)
+      .withReference(
+        client.data.referencePayloadBuilder().withId(id1).payload()
+      )
+      .do()
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .getterById()
+      .withClassName(refSourceClassName)
+      .withId(id2)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id2,
+            properties: {
+              refProp: [{
+                beacon: `weaviate://localhost/${id1}`,
+                href: `/v1/objects/${id1}`
+              }]
+            },
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("replaces reference with consistency_level set", async () => {
+    const id1 = "84c58d72-7303-4528-90d2-ebaa39bdd9d4";
+    const props1 = { stringProp: "foobar" };
+
+    const id2 = "6ca5a30f-f3df-400f-92d2-7de1a48d80ac";
+
+    await client.data
+      .creator()
+      .withClassName(thingClassName)
+      .withProperties(props1)
+      .withId(id1)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(props1);
+        expect(res.id).toEqual(id1);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .creator()
+      .withClassName(refSourceClassName)
+      .withId(id2)
+      .do()
+      .then((res) => {
+        expect(res.id).toEqual(id2);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .referenceReplacer()
+      .withId(id2)
+      .withReferenceProperty("refProp")
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ONE)
+      .withReferences(
+        client.data.referencePayloadBuilder().withId(id1).payload()
+      )
+      .do()
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
+  it("deletes reference with consistency_level set", async () => {
+    const id1 = "cfc3151c-6f45-45e2-bb6a-55789c1fbbb2";
+    const props1 = { stringProp: "foobar" };
+
+    const id2 = "70ff8bc0-1d3d-4df4-8bf0-774806ba53e3";
+
+    await client.data
+      .creator()
+      .withClassName(thingClassName)
+      .withProperties(props1)
+      .withId(id1)
+      .do()
+      .then((res) => {
+        expect(res.properties).toEqual(props1);
+        expect(res.id).toEqual(id1);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .creator()
+      .withClassName(refSourceClassName)
+      .withId(id2)
+      .do()
+      .then((res) => {
+        expect(res.id).toEqual(id2);
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .referenceCreator()
+      .withId(id2)
+      .withReferenceProperty("refProp")
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ONE)
+      .withReference(
+        client.data.referencePayloadBuilder().withId(id1).payload()
+      )
+      .do()
+      .catch((e) => fail("it should not have errord: " + e));
+
+    await client.data
+      .getterById()
+      .withClassName(refSourceClassName)
+      .withId(id2)
+      .do()
+      .then((res) => {
+        expect(res).toEqual(
+          expect.objectContaining({
+            id: id2,
+            properties: {
+              refProp: [{
+                beacon: `weaviate://localhost/${id1}`,
+                href: `/v1/objects/${id1}`
+              }]
+            },
+          })
+        );
+      })
+      .catch((e) => fail("it should not have errord: " + e));
+
+    return client.data
+      .referenceDeleter()
+      .withId(id2)
+      .withReferenceProperty("refProp")
+      .withConsistencyLevel(weaviate.replication.ConsistencyLevel.ONE)
+      .withReference(
+        client.data.referencePayloadBuilder().withId(id1).payload()
+      )
+      .do()
+      .catch((e) => fail("it should not have errord: " + e));
+  })
+
   it("tears down and cleans up", () => {
     return Promise.all([
       client.schema.classDeleter().withClassName(thingClassName).do(),

--- a/data/merger.js
+++ b/data/merger.js
@@ -22,6 +22,11 @@ export default class Merger {
     return this;
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateClassName = () => {
     if (!isValidStringProperty(this.className)) {
       this.errors = [
@@ -57,7 +62,7 @@ export default class Merger {
       );
     }
 
-    return this.objectsPath.buildMerge(this.id, this.className)
+    return this.objectsPath.buildMerge(this.id, this.className, this.consistencyLevel)
       .then(path => this.client.patch(path, this.payload()));
   };
 }

--- a/data/path.js
+++ b/data/path.js
@@ -8,11 +8,12 @@ export class ObjectsPath {
     this.dbVersionSupport = dbVersionSupport;
   }
 
-  buildCreate() {
-    return this.build({}, []);
+  buildCreate(consistencyLevel) {
+    return this.build({consistencyLevel}, [this.addQueryParams]);
   }
-  buildDelete(id, className) {
-    return this.build({id, className}, [this.addClassNameDeprecatedNotSupportedCheck, this.addId]);
+  buildDelete(id, className, consistencyLevel) {
+    return this.build({id, className, consistencyLevel}, 
+      [this.addClassNameDeprecatedNotSupportedCheck, this.addId, this.addQueryParams]);
   }
   buildCheck(id, className) {
     return this.build({id, className}, [this.addClassNameDeprecatedNotSupportedCheck, this.addId]);
@@ -24,11 +25,13 @@ export class ObjectsPath {
   buildGet(className, limit, additionals) {
     return this.build({className, limit, additionals}, [this.addQueryParamsForGet]);
   }
-  buildUpdate(id, className) {
-    return this.build({id, className}, [this.addClassNameDeprecatedCheck, this.addId]);
+  buildUpdate(id, className, consistencyLevel) {
+    return this.build({id, className, consistencyLevel}, 
+      [this.addClassNameDeprecatedCheck, this.addId, this.addQueryParams]);
   }
-  buildMerge(id, className) {
-    return this.build({id, className}, [this.addClassNameDeprecatedCheck, this.addId]);
+  buildMerge(id, className, consistencyLevel) {
+    return this.build({id, className, consistencyLevel}, 
+      [this.addClassNameDeprecatedCheck, this.addId, this.addQueryParams]);
   }
 
   build(params, modifiers) {
@@ -114,7 +117,7 @@ export class ReferencesPath {
     this.dbVersionSupport = dbVersionSupport;
   }
 
-  build(id, className, property) {
+  build(id, className, property, consistencyLevel) {
     return this.dbVersionSupport.supportsClassNameNamespacedEndpointsPromise().then(support => {
       var path = objectsPathPrefix;
       if (support.supports) {
@@ -132,6 +135,9 @@ export class ReferencesPath {
       path = `${path}/references`;
       if (isValidStringProperty(property)) {
         path = `${path}/${property}`;
+      }
+      if (isValidStringProperty(consistencyLevel)) {
+        path = `${path}?consistency_level=${consistencyLevel}`;
       }
       return path;
     });

--- a/data/path.test.js
+++ b/data/path.test.js
@@ -1,0 +1,51 @@
+import { DbVersionProvider } from "../test/dbVersionProvider"
+import { DbVersionSupport } from "../utils/dbVersion"
+import { ObjectsPath, ReferencesPath } from "./path"
+
+// This can be anything > 1.14.2, to support class-namespaced urls.
+// The actual value is not used for anything else
+const version = "1.18.0"
+
+const objectsPathBuilder = new ObjectsPath(
+  new DbVersionSupport(
+    new DbVersionProvider(version)
+  )
+);
+
+const refsPathBuilder = new ReferencesPath(
+  new DbVersionSupport(
+    new DbVersionProvider(version)
+  )
+);
+
+describe("paths", () => {
+  it("builds object create", () => {
+    return objectsPathBuilder.buildCreate("ONE")
+      .then(path => expect(path).toEqual("/objects?consistency_level=ONE"))
+      .catch(e => fail(`unexpected error: ${e}`));
+  })
+
+  it("builds object delete", () => {
+    return objectsPathBuilder.buildDelete("123456", "SomeClass", "ALL")
+      .then(path => expect(path).toEqual("/objects/SomeClass/123456?consistency_level=ALL"))
+      .catch(e => fail(`unexpected error: ${e}`));
+  })
+
+  it("builds object merge", () => {
+    return objectsPathBuilder.buildMerge("123456", "SomeClass", "QUORUM")
+      .then(path => expect(path).toEqual("/objects/SomeClass/123456?consistency_level=QUORUM"))
+      .catch(e => fail(`unexpected error: ${e}`));
+  })
+
+  it("builds object update", () => {
+    return objectsPathBuilder.buildUpdate("123456", "SomeClass", "ONE")
+      .then(path => expect(path).toEqual("/objects/SomeClass/123456?consistency_level=ONE"))
+      .catch(e => fail(`unexpected error: ${e}`));
+  })
+
+  it("builds references", () => {
+    return refsPathBuilder.build("123456", "SomeClass", "SomeProp", "ALL")
+      .then(path => expect(path).toEqual("/objects/SomeClass/123456/references/SomeProp?consistency_level=ALL"))
+      .catch(e => fail(`unexpected error: ${e}`));
+  })
+})

--- a/data/referenceCreator.js
+++ b/data/referenceCreator.js
@@ -26,6 +26,11 @@ export default class ReferenceCreator {
     return this;
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateIsSet = (prop, name, setter) => {
     if (prop == undefined || prop == null || prop.length == 0) {
       this.errors = [
@@ -56,7 +61,7 @@ export default class ReferenceCreator {
     }
 
     return Promise.all([
-      this.referencesPath.build(this.id, this.className, this.refProp),
+      this.referencesPath.build(this.id, this.className, this.refProp, this.consistencyLevel),
       this.beaconPath.rebuild(this.reference.beacon)
     ]).then(results => {
       const path = results[0];

--- a/data/referenceDeleter.js
+++ b/data/referenceDeleter.js
@@ -26,6 +26,11 @@ export default class ReferenceDeleter {
     return this;
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateIsSet = (prop, name, setter) => {
     if (prop == undefined || prop == null || prop.length == 0) {
       this.errors = [
@@ -56,7 +61,7 @@ export default class ReferenceDeleter {
     }
 
     return Promise.all([
-      this.referencesPath.build(this.id, this.className, this.refProp),
+      this.referencesPath.build(this.id, this.className, this.refProp, this.consistencyLevel),
       this.beaconPath.rebuild(this.reference.beacon)
     ]).then(results => {
       const path = results[0];

--- a/data/referenceReplacer.js
+++ b/data/referenceReplacer.js
@@ -26,6 +26,11 @@ export default class ReferenceReplacer {
     return this;
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   validateIsSet = (prop, name, setter) => {
     if (prop == undefined || prop == null || prop.length == 0) {
       this.errors = [
@@ -59,7 +64,7 @@ export default class ReferenceReplacer {
       : Promise.resolve([]);
 
     return Promise.all([
-      this.referencesPath.build(this.id, this.className, this.refProp),
+      this.referencesPath.build(this.id, this.className, this.refProp, this.consistencyLevel),
       payloadPromise
     ]).then(results => {
       const path = results[0];

--- a/data/updater.js
+++ b/data/updater.js
@@ -40,6 +40,11 @@ export default class Updater {
     }
   };
 
+  withConsistencyLevel = (cl) => {
+    this.consistencyLevel = cl;
+    return this;
+  };
+
   payload = () => ({
     properties: this.properties,
     class: this.className,
@@ -60,7 +65,7 @@ export default class Updater {
       );
     }
 
-    return this.objectsPath.buildUpdate(this.id, this.className)
+    return this.objectsPath.buildUpdate(this.id, this.className, this.consistencyLevel)
       .then(path => this.client.put(path, this.payload()));
   };
 }

--- a/schema/journey.test.js
+++ b/schema/journey.test.js
@@ -37,7 +37,7 @@ describe("schema", () => {
       .withClass(doomedClass)
       .do()
       .catch(err =>
-        expect(err).toEqual("usage error (422): {\"code\":606,\"message\":\"tokenization in body should be one of [word field]\"}")
+        expect(err).toEqual("usage error (422): {\"code\":606,\"message\":\"properties.0.tokenization in body should be one of [word field]\"}")
       );
   });
 

--- a/test/dbVersionProvider.js
+++ b/test/dbVersionProvider.js
@@ -1,0 +1,9 @@
+export class DbVersionProvider {
+  constructor(version) {
+    this.version = version;
+  }
+
+  getVersionPromise() {
+    return Promise.resolve(this.version);
+  }
+}


### PR DESCRIPTION
In preparation for the v1.18 release, all write endpoint builders and their associated code have been updated to support the consistency_level query parameter for tunable consistency